### PR TITLE
fix: hint text is not visible in some devices

### DIFF
--- a/app/src/main/java/com/github/cardswipe/MainActivity.kt
+++ b/app/src/main/java/com/github/cardswipe/MainActivity.kt
@@ -68,7 +68,7 @@ class MainActivity : ComponentActivity() {
                             .fillMaxSize()
                             .background(color = Color.White)
                             .padding(contentPadding),
-                        verticalArrangement = Arrangement.spacedBy(50.dp)
+                        verticalArrangement = Arrangement.SpaceBetween
                     ) {
                         Box(
                             modifier = Modifier


### PR DESCRIPTION
Now, hint text is visible on all the devices

Fixes #13

Tested Smartphone:

Device: Realme X
Android version: 11
Screenshot
![screenshot_realmeX](https://github.com/PratyushSingh07/BumbleCardSwipe/assets/40030547/9ae22e78-9b1d-4e3d-84cb-64642964a181)

Device: Realme 6
Android version: 11
Screenshot
![screenshot_realme6](https://github.com/PratyushSingh07/BumbleCardSwipe/assets/40030547/977424e0-7612-49f8-bded-3c3d15bdfb39)
